### PR TITLE
Add formspree to SlackInviteForm component

### DIFF
--- a/src/components/slackInviteForm.js
+++ b/src/components/slackInviteForm.js
@@ -1,10 +1,10 @@
 import React from "react"
 
 const SlackInviteForm = () => (
-  <>
-    <input placeholder="Email Address" />
-    <button type="input">Request Invite</button>
-  </>
+  <form action="https://formspree.io/info@ladevs.org" method="POST">
+    <input type="email" name="_invte_requested" placeholder="Email Address" />
+    <input type="submit" value="Request Invite" />
+  </form>
 );
 
 export default SlackInviteForm;


### PR DESCRIPTION
Adds Formspree.io functionality to email request.
<img width="554" alt="Screen Shot 2019-03-16 at 12 08 58 PM" src="https://user-images.githubusercontent.com/19210117/54480335-54a92e80-47e4-11e9-8190-7d9d06f6e30f.png">
