### PR TITLE
Fix seo title since auto appends with 'LA Devs'

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,11 +3,11 @@ import React from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import SlackInviteForm from "../components/slackInviteForm"
-import { SEO_TAGS, SEO_TITLE } from '../utils/constants';
+import { SEO_TAGS, SEO_TITLES } from '../utils/constants';
 
 const IndexPage = () => (
   <Layout>
-    <SEO title={SEO_TITLE} keywords={SEO_TAGS} />
+    <SEO title={SEO_TITLES.homepage} keywords={SEO_TAGS} />
     <h1>Under Construction</h1>
     <h4>A new home for Los Angeles based software developers is being built</h4>
     <p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,11 +3,11 @@ import React from "react"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import SlackInviteForm from "../components/slackInviteForm"
-import { SEO_TAGS } from '../utils/constants';
+import { SEO_TAGS, SEO_TITLE } from '../utils/constants';
 
 const IndexPage = () => (
   <Layout>
-    <SEO title="LA Devs - A Community for Los Angeles Based Software Developers" keywords={SEO_TAGS} />
+    <SEO title={SEO_TITLE} keywords={SEO_TAGS} />
     <h1>Under Construction</h1>
     <h4>A new home for Los Angeles based software developers is being built</h4>
     <p>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,4 @@
 export const EMAIL_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 export const LA_DEVS_EMAIL = 'info@ladevs.org';
 export const SEO_TAGS = ['los angeles', 'la', 'slack', 'software', 'developers', 'networking', 'community'];
+export const SEO_TITLE = 'A Community for Los Angeles Based Software Developers';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,6 @@
 export const EMAIL_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 export const LA_DEVS_EMAIL = 'info@ladevs.org';
 export const SEO_TAGS = ['los angeles', 'la', 'slack', 'software', 'developers', 'networking', 'community'];
-export const SEO_TITLE = 'A Community for Los Angeles Based Software Developers';
+export const SEO_TITLES = {
+  homepage: 'A Community for Los Angeles Based Software Developers',
+};


### PR DESCRIPTION
Relates To: https://github.com/la-devs/issue-tracking/issues/16

#### Changes Included:

- Move SEO title to constants.js
- Change SEO title to not include `LA Devs` assuming that `| LA Devs` is appended automatically
