### PR TITLE
Fix webpack css import

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= favicon_link_tag asset_path('favicon.png') %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",
+  "scripts": {
+    "start": "./bin/webpack-dev-server"
+  },
   "devDependencies": {
     "webpack-dev-server": "^3.7.2"
   }


### PR DESCRIPTION
Relates To: rails 6 overhaul

#### Changes Included:

- Fix issue with importing CSS into React environment with webpack compiling

Please ensure your PR follows the [Contributor Covenant Code of Conduct](https://github.com/la-devs/ladevs.org/blob/master/CODE_OF_CONDUCT.md). 
